### PR TITLE
Remove / in second self-closing tags example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ In self-closing tags, the trailing `/` is optional. This is valid too:
 <img
   src="https://media.giphy.com/media/3o6MbkZSYy4mI3gLYc/giphy.gif"
   alt="A policeman"
-/>
+>
 ```
 
 Enough review, let's write some HTML!


### PR DESCRIPTION
I think the point is to outline that `<img … />` and `<img … >` are both valid, but currently both examples are identical :)

## Before

<img width="933" alt="Screen Shot 2021-08-11 at 9 44 09 PM" src="https://user-images.githubusercontent.com/3092522/129125558-0bcf1a27-074c-450c-a398-a9625fed19f2.png">


## After

<img width="933" alt="Screen Shot 2021-08-11 at 9 44 33 PM" src="https://user-images.githubusercontent.com/3092522/129125576-1c97acb5-94fa-4ff2-80e9-446753c62e01.png">
